### PR TITLE
Fix typo in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ https://github.com/nferraz/ChatBot-Simple/issues
 
 Or fork the code on github:
 
-https://github.com/nferraz/st
+https://github.com/nferraz/ChatBot-Simple
 
 
 LICENSE AND COPYRIGHT


### PR DESCRIPTION
The repo in link in README.md had `st` instead of `ChatBot-Simple. Fixed that.
